### PR TITLE
Added to host.html and headline.html

### DIFF
--- a/_includes/headline.html
+++ b/_includes/headline.html
@@ -1,9 +1,9 @@
 <div class='container center headline'>
 
     <h3>You're invited to the</h3>
-    <h1>Software Carpentry Instructor & Helper Retreat</h1>
+    <h1>Software & Data Carpentry Instructor & Helper Retreat</h1>
     <h3>November 14, 2015</h3>
 
-    <p>We're inviting Software Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related. For more details, check out the <a href="">blog post</a>, or <a href="mailto:mentoring@lists.software-carpentry.org">email the Mentoring Committee</a>.</p>
+    <p>We're inviting all Software & Data Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related. For more details, check out the <a href="">blog post</a>, or <a href="mailto:mentoring@lists.software-carpentry.org">email the Mentoring Committee</a>.</p>
 
 </div>

--- a/_includes/host.html
+++ b/_includes/host.html
@@ -7,5 +7,6 @@
         <li><strong>Reach out to your community</strong> to let them know what's happening.</li>
         <li><strong>Arrange for a video connection</strong> to the global Google Hangout on Air, so your site can lead a session on the <a href="#broadcast">broadcast sessions</a> list above.</li>
         <li><strong>Brainstorm with your community</strong> on what kind of broadcast session you'd all like to lead; we'd like every site to try to lead a one-hour session, if possible.</li>
+        <li></strong>Create a schedule for local practice teaching sessions</strong> - encourage everyone to try something new!</li>
     </ul>
 </div>


### PR DESCRIPTION
Added a line under Hosting a Site to let hosts know they will also need to plan what goes on locally at their site (i.e., getting others to do practice teaching sessions locally to eachother)

Also added Data Carpentry to website in headline.
