### PR TITLE
Add liquid filter for HTTPS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,9 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.github.url }}">
-  <link rel="stylesheet" href="{{ "/css/bootstrap.css" | prepend: site.github.url }}">
-  <link rel="stylesheet" href="{{ "/css/custom.css" | prepend: site.github.url }}">
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.github.url | replace_first: 'http', 'https' }}">
+  <link rel="stylesheet" href="{{ "/css/bootstrap.css" | prepend: site.github.url | replace_first: 'http', 'https' }}">
+  <link rel="stylesheet" href="{{ "/css/custom.css" | prepend: site.github.url | replace_first: 'http', 'https' }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,10 +3,10 @@
     <div class='container'>
       <div class="navbar-header">
         <a href="https://software-carpentry.org/" class="navbar-brand">
-          <img alt="Software Carpentry logo" src="{{site.github.url}}/img/software-carpentry-banner.png">
+          <img alt="Software Carpentry logo" src="{{site.github.url | replace_first: 'http', 'https'}}/img/software-carpentry-banner.png">
         </a>
         <a href="http://datacarpentry.org/" class="navbar-brand">
-          <img alt="Data Carpentry logo" src="{{site.github.url}}/img/data-carpentry-banner.png">
+          <img alt="Data Carpentry logo" src="{{site.github.url | replace_first: 'http', 'https'}}/img/data-carpentry-banner.png">
         </a>
       </div>
     </div>


### PR DESCRIPTION
Firefox and Chrome complains when using HTTPS (https://swcarpentry.github.io/instructor-retreat-2015/) and do not use the CSS.

![screen shot 2015-09-19 at 08 29 02](https://cloud.githubusercontent.com/assets/1506457/9976013/711ab21e-5ea9-11e5-9c63-ebfd46fc27f9.png)

This should solve the problem.
