### PR TITLE
add Seattle's broadcast session & use UTC time

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -15,63 +15,63 @@
             <td>Notes & Questions</td>
         </tr>
         <tr>
-            <td>3:00 AM GMT</td>
+            <td>3:00 AM UTC</td>
             <td>Contributorship session</td>
             <td>Isabell Kiral-Kornek</td>
             <td>Walk through of the process of contributing back to Software Carpentry</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>11:00 AM GMT</td>
+            <td>11:00 AM UTC</td>
             <td>Contributorship session</td>
             <td>Greg Wilson</td>
             <td>Walk through of the process of contributing back to Software Carpentry</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>3:00 PM GMT</td>
+            <td>3:00 PM UTC</td>
             <td>Interactive learning</td>
             <td>Lex Nederbragt</td>
             <td>Simple online and offline resources for making learning more interactive</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>4:00 PM GMT</td>
+            <td>4:00 PM UTC</td>
             <td>Alternative version control lesson</td>
             <td>Remi Daigle</td>
             <td>Teaching Git and Github without the command line</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>5:00 PM GMT</td>
+            <td>5:00 PM UTC</td>
             <td>Contributorship session</td>
             <td>Christina Koch</td>
             <td>Walk through of the process of contributing back to Software Carpentry</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>6:00 PM GMT</td>
+            <td>6:00 PM UTC</td>
             <td>Version control pedagogy</td>
             <td>John Corless</td>
             <td>Split-screen approach to teaching Version Control</td>
             <td><a href=''>Etherpad</a></td>
 	  </tr>
 	<tr>
-            <td>7:00 PM GMT</td>
+            <td>7:00 PM UTC</td>
             <td>R-novice-gapminder</td>
             <td>Kara Woo</td>
             <td>Trying out new lesson material from R-novice-gapminder</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>8:00 PM GMT</td>
+            <td>8:00 PM UTC</td>
             <td>Socrative</td>
             <td>Kate Hertweck</td>
             <td>How to test student learning in real time via Socrative</td>
             <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
-            <td>11:00 PM GMT</td>
+            <td>11:00 PM UTC</td>
             <td>Software installation session</td>
             <td>Matt Davis</td>
             <td>Tips and tricks on installing workshop software</td>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -55,6 +55,13 @@
             <td>John Corless</td>
             <td>Split-screen approach to teaching Version Control</td>
             <td><a href=''>Etherpad</a></td>
+	  </tr>
+	<tr>
+            <td>7:00 PM GMT</td>
+            <td>R-novice-gapminder</td>
+            <td>Kara Woo</td>
+            <td>Trying out new lesson material from R-novice-gapminder</td>
+            <td><a href=''>Etherpad</a></td>
         </tr>
         <tr>
             <td>8:00 PM GMT</td>


### PR DESCRIPTION
Seattle will broadcast a hands-on demo of the r-novice-gapminder lesson, led by Kara Woo at 7pm UTC. Also, the etherpad uses UTC, and I'm pretty sure its the same as GMT, so I think its better to be consistent.
